### PR TITLE
refactor `UserOrganizationMapping.save` override into Django signal

### DIFF
--- a/tahoe_sites/models.py
+++ b/tahoe_sites/models.py
@@ -6,7 +6,9 @@ import uuid
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db import models
+from django.db.models.signals import pre_save
 from django.db.utils import IntegrityError
+from django.dispatch import receiver
 from organizations.models import Organization
 
 from tahoe_sites import zd_helpers
@@ -51,22 +53,18 @@ class UserOrganizationMapping(models.Model):
         :param user: User to check
         :return: <True> if the user already mapped to an organization, <False> otherwise
         """
-        return cls.objects.filter(user=user).count() > 0
+        return cls.objects.filter(user=user).exists()
 
-    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
-        """
-        Override save to control user uniqueness rule
 
-        :param force_insert: inherited
-        :param force_update: inherited
-        :param using: inherited
-        :param update_fields: inherited
-        :return: inherited
-        """
-        if not self.pk and self.is_user_already_mapped(user=self.user):
-            raise IntegrityError('Cannot add user to organization. User already added to an organization!')
+@receiver(pre_save, sender=UserOrganizationMapping)
+def prevent_adding_user_to_two_organizations(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+    Prevent adding the same user to two organizations.
 
-        super().save(force_insert, force_update, using, update_fields)
+    TODO: Use `user = models.OneToOneField()` instead of this check.
+    """
+    if not instance.pk and instance.is_user_already_mapped(user=instance.user):
+        raise IntegrityError('Cannot add user to organization. User already added to an organization!')
 
 
 class TahoeSite(models.Model):


### PR DESCRIPTION
This helps to ensure `save()` don't break on Django updates.

Review pull request on:
 
 - #24 