### PR TITLE
fix typo in `tox.in` and `ci.yml` and run tests again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - python-version: 3.8
-            tox-env: py38-codelint  
+            tox-env: py3-codelint
           - python-version: 3.5
             tox-env: py35-codetest-noorgs
           - python-version: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py38}-codetest-{noorgs,withorgs},py38-codelint
+envlist = {py35,py38}-codetest-{noorgs,withorgs},py3-codelint
 
 [testenv]
 setenv =
@@ -14,10 +14,9 @@ deps =
     noorgs,codelint: https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler13.tar.gz
     withorgs: https://github.com/appsembler/edx-organizations/archive/5.2.0-appsembler13.tar.gz
 
-[testenv:codetest]
 commands =
     python -Wd -m pytest {posargs} --cov-report term-missing --cov=./tahoe_sites --cov-fail-under=80
 
-[testenv:codelint]
+[testenv:py3-codelint]
 commands =
     pylint tahoe_sites


### PR DESCRIPTION
before that tests weren't running at all due to 7b1b8c96bc000911d8f289830039a85fac7165ff