### PR TITLE
remove asserts from production code

### DIFF
--- a/tahoe_sites/api.py
+++ b/tahoe_sites/api.py
@@ -173,8 +173,11 @@ def update_admin_role_in_organization(user, organization, set_as_admin=False):
     helpers like `is_active_admin_on_organization` should take care of the `is_active` status.
     """
     # Sanity check for params to ensure we're updating a single entry at once.
-    assert user, 'Parameter `user` should not be None'
-    assert organization, 'Parameter `organization` should not be None'
+    if not user:
+        raise ValueError('Parameter `user` should not be None')
+
+    if not organization:
+        raise ValueError('Parameter `organization` should not be None')
 
     UserOrganizationMapping.objects.filter(
         user=user,

--- a/tahoe_sites/tests/test_api.py
+++ b/tahoe_sites/tests/test_api.py
@@ -393,10 +393,10 @@ class TestAPIHelpers(DefaultsForTestsMixin):
         """
         Test update_admin_role_in_organization when having None parameters.
         """
-        with pytest.raises(AssertionError, match='Parameter `user` should not be None'):
+        with pytest.raises(ValueError, match='Parameter `user` should not be None'):
             api.update_admin_role_in_organization(user=None, organization=object())
 
-        with pytest.raises(AssertionError, match='Parameter `organization` should not be None'):
+        with pytest.raises(ValueError, match='Parameter `organization` should not be None'):
             api.update_admin_role_in_organization(user=object(), organization=None)
 
     @mock.patch('tahoe_sites.api.get_organization_by_site')


### PR DESCRIPTION
as per: https://github.com/appsembler/xblock-grade-fetcher/pull/8#discussion_r818666491

 > Beware that if you run python with the `-O` flag, it doesn't execute `assert` statements. I assume that edX doesn't use that flag, but especially since this is in a reusable module and there isn't any way to control what flags get used, it's risky to rely on `assert` to avoid bad data or enforce anything like a security constraint.
