### PR TITLE
add missing links for v0.1.3 and v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- Note: Update the `Unreleased link` after adding a new release -->
 
-## [0.1.4] - 2022-03-03
+## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.1.4...HEAD)
+
+## [0.1.4](https://github.com/appsembler/tahoe-sites/compare/v0.1.3...v0.1.4) - 2022-03-03
  - Fixing a syntax error in 0.1.3 that crashed the package
  - Removing migration file that deletes `is_active` field
  - Removing `assert` from production code 
 
-## [0.1.3] - 2022-03-03
+## [0.1.3](https://github.com/appsembler/tahoe-sites/compare/v0.1.2...v0.1.3) - 2022-03-03
  - Remove is_active_admin_on_any_organization API
  - Add more APIs for getting current Site
  - Add get_organization_by_course API
@@ -20,13 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Remove is_active Field and rely on User.is_active
  - Move Backends to this repo
 
-## [0.1.2] - 2022-02-24
+## [0.1.2](https://github.com/appsembler/tahoe-sites/compare/v0.1.1...v0.1.2) - 2022-02-24
  - Move get_current_organization to this package
  - New API helper update_admin_role_in_organization
  - One Organization Per User
  - New API Helper add_user_to_organization
 
-## [0.1.1] - 2022-02-10
+## [0.1.1](https://github.com/appsembler/tahoe-sites/compare/ef43ca91543432335e6ddb9b26cab11059811f64...v0.1.1) - 2022-02-10
  - First release to be publish to PyPi
  - Most of the Python API helpers are ready to be used
  - starting changelog
@@ -34,6 +36,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1
  - Initial GitHub repo. Not released to PyPi.
 
-[unreleased]: https://github.com/appsembler/tahoe-sites/compare/v0.1.2...HEAD
-[0.1.2]: https://github.com/appsembler/tahoe-sites/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/appsembler/tahoe-sites/compare/ef43ca91543432335e6ddb9b26cab11059811f64...v0.1.1


### PR DESCRIPTION
Now using inline links, so they're easy to spot and update.