### PR TITLE
Fix local tox not setting the correct pip Version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist = {py35,py38}-codetest-{noorgs,withorgs},py38-codelint
 
 [testenv]
+download = True
+
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = test_settings


### PR DESCRIPTION
## Change description

When we run tox locally (in Ubuntu 20.04); it doesn't install the latest related pip according to the chosen Python version. The `download` flag is to tell tox to upgrade pip before installing any other package

This consumed about 3 hours of work to figure out why my local tox behaves differently than Github actions tox.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
