### PR TITLE
Change behaviour of get_organization_for_user

### DIFF
--- a/tahoe_sites/api.py
+++ b/tahoe_sites/api.py
@@ -50,13 +50,14 @@ def get_uuid_by_organization(organization):
     return TahoeSite.objects.get(organization=organization).site_uuid
 
 
-def get_organization_for_user(user, fail_if_inactive=True, fail_if_site_admin=False):
+def get_organization_for_user(user, fail_if_inactive=False, fail_if_site_admin=False):
     """
-    Return the organization related to the given user. By default, the it will return None is the user
-    is inactive in the organization
+    Return the organization related to the given user. By default, it will return the related organization regardless
+    of the user being active or not
 
     :param user: user to filter on
-    :param fail_if_inactive: Fail if the user is inactive (default = True)
+    :param fail_if_inactive: Fail if the user is inactive (default = False). If set to <True>; and exception
+            will be raised when the user is inactive (Organization.DoesNotExist)
     :param fail_if_site_admin: Fail if the user is an admin on the organization (default = False)
     :return: Organization objects related to the given user
     """

--- a/tahoe_sites/backends.py
+++ b/tahoe_sites/backends.py
@@ -58,7 +58,7 @@ class OrganizationMemberBackend(AllowAllUsersModelBackend):
         if not is_main_site(site) and user and not user.is_superuser:
             try:
                 # `get_organization_for_user` never return `None` but raises DoesNotExist if no organization is found
-                user_organization = get_organization_for_user(user=user, fail_if_inactive=False)
+                user_organization = get_organization_for_user(user=user)
                 if get_organization_by_site(site=site) == user_organization:
                     result = user
             except Organization.DoesNotExist:

--- a/tahoe_sites/tests/test_api.py
+++ b/tahoe_sites/tests/test_api.py
@@ -85,7 +85,7 @@ class TestAPIHelpers(DefaultsForTestsMixin):
         """
         assert api.get_uuid_by_organization(self.default_org) == self.default_org.edx_uuid
 
-    def test_get_organization_for_user_default(self):
+    def test_get_organization_for_user_only_active_users(self):
         """
         Verify that get_organization_for_user helper returns only related to active user
         """
@@ -101,18 +101,18 @@ class TestAPIHelpers(DefaultsForTestsMixin):
         self.org2_first_user.is_active = False
         self.org2_first_user.save()
         with self.assertRaises(expected_exception=Organization.DoesNotExist):
-            api.get_organization_for_user(self.org2_first_user)
+            api.get_organization_for_user(self.org2_first_user, fail_if_inactive=True)
 
-    def test_get_organization_for_user_with_inactive_users(self):
+    def test_get_organization_for_user_default(self):
         """
-        Verify that get_organization_for_user helper can return all organization related to a user
-        including organizations having that user deactivated
+        Verify that get_organization_for_user helper returns the organization related to a user
+        regardless of the user being active or not
         """
         self._prepare_mapping_data()
 
         self.default_user.is_active = False
         self.default_user.save()
-        assert api.get_organization_for_user(self.default_user, fail_if_inactive=False) == self.default_org
+        assert api.get_organization_for_user(self.default_user) == self.default_org
 
     def test_get_organization_for_user_without_admins(self):
         """


### PR DESCRIPTION

## Change description
Change behavior of `get_organization_for_user` . Switch the default value of `fail_if_inactive` from `True` to `False`

The reason is that `edx-platform` default behavior is not caring about the user being active or not. See [get_single_user_organization method](https://github.com/appsembler/edx-platform/blob/58dd437bff70877c0c7a4b92758234acead44920/openedx/core/djangoapps/appsembler/sites/utils.py#L202)

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
