### PR TITLE
Updates and New APIs

### DIFF
--- a/tahoe_sites/api.py
+++ b/tahoe_sites/api.py
@@ -378,6 +378,21 @@ def is_exist_organization_user_by_email(email, organization, must_be_active=Fals
     return user is not None
 
 
+def deprecated_is_existing_email_but_not_linked_yet(email):
+    """
+    TODO: This method os a temporary one; to be removed after integrating IDP with Studio
+    Check if the given email is related to an existing user but not linked to any site yet
+
+    :param email: user's email to filter on
+    :return: boolean
+    """
+    return get_user_model().objects.filter(
+        email=email,
+    ).exclude(
+        pk__in=UserOrganizationMapping.objects.filter().values('user_id'),
+    ).exists()
+
+
 def deprecated_get_admin_users_queryset_by_email(email):
     """
     TODO: This method os a temporary one; to be removed after integrating IDP with Studio

--- a/tahoe_sites/api.py
+++ b/tahoe_sites/api.py
@@ -356,7 +356,7 @@ def is_exist_organization_user_by_email(email, organization, must_be_active=Fals
     return user is not None
 
 
-def get_admin_users_queryset_by_email(email):
+def deprecated_get_admin_users_queryset_by_email(email):
     """
     TODO: This method os a temporary one; to be removed after integrating IDP with Studio
     Get a queryset of users where the given email represents an admin, regardless of being active or not

--- a/tahoe_sites/api.py
+++ b/tahoe_sites/api.py
@@ -19,6 +19,7 @@ import crum
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
+from django.db.models import Q
 from organizations import api as organizations_api
 from organizations.models import Organization, OrganizationCourse
 
@@ -337,6 +338,27 @@ def get_organization_user_by_email(email, organization, fail_if_inactive=False):
     return get_user_model().objects.get(
         pk__in=UserOrganizationMapping.objects.filter(organization=organization, **extra_params).values('user_id'),
         email=email,
+    )
+
+
+def get_organization_user_by_username_or_email(username_or_email, organization, fail_if_inactive=False):
+    """
+    Get the user owning the given email address in the given organization. With an option to return None if
+    the user is inactive
+
+    :param username_or_email: user's username or email to search for
+    :param organization: organization to filter on
+    :param fail_if_inactive: when <True>; the method will fail if the user is inactive. (default is False)
+    :return: user object
+    """
+    if fail_if_inactive:
+        extra_params = {'user__is_active': True}
+    else:
+        extra_params = {}
+
+    return get_user_model().objects.get(
+        Q(email=username_or_email) | Q(username=username_or_email),
+        pk__in=UserOrganizationMapping.objects.filter(organization=organization, **extra_params).values('user_id'),
     )
 
 

--- a/tahoe_sites/tests/test_api.py
+++ b/tahoe_sites/tests/test_api.py
@@ -638,3 +638,19 @@ class TestAPIHelpers(DefaultsForTestsMixin):
         assert list(api.deprecated_get_admin_users_queryset_by_email(email=email)) == [
             self.default_user, user_same_email
         ]
+
+    @ddt.data(True)
+    def test_deprecated_is_existing_email_but_not_linked_yet(self, is_active):
+        """
+        Verify that deprecated_is_existing_email_but_not_linked_yet returns the correct result
+        """
+        email = 'testing.email.for.deprecated.method@example.com'
+        assert not api.deprecated_is_existing_email_but_not_linked_yet(email=email)
+
+        user = UserFactory.create(email=email)
+        user.is_active = is_active
+        user.save()
+        assert api.deprecated_is_existing_email_but_not_linked_yet(email=email)
+
+        create_organization_mapping(user=user, organization=self.default_org)
+        assert not api.deprecated_is_existing_email_but_not_linked_yet(email=email)

--- a/tahoe_sites/tests/test_api.py
+++ b/tahoe_sites/tests/test_api.py
@@ -567,9 +567,9 @@ class TestAPIHelpers(DefaultsForTestsMixin):
             assert not api.is_exist_organization_user_by_email(email='some_email', organization=mock.Mock())
 
     @ddt.data(True, False)
-    def test_get_admin_users_queryset_by_email(self, is_active):
+    def test_deprecated_get_admin_users_queryset_by_email(self, is_active):
         """
-        Verify that get_admin_users_queryset_by_email returns the correct queryset
+        Verify that deprecated_get_admin_users_queryset_by_email returns the correct queryset
         """
         self.default_user.is_active = is_active
         self.default_user.save()
@@ -583,8 +583,10 @@ class TestAPIHelpers(DefaultsForTestsMixin):
 
         mapping1.is_admin = True
         mapping1.save()
-        assert list(api.get_admin_users_queryset_by_email(email=email)) == [self.default_user]
+        assert list(api.deprecated_get_admin_users_queryset_by_email(email=email)) == [self.default_user]
 
         mapping2.is_admin = True
         mapping2.save()
-        assert list(api.get_admin_users_queryset_by_email(email=email)) == [self.default_user, user_same_email]
+        assert list(api.deprecated_get_admin_users_queryset_by_email(email=email)) == [
+            self.default_user, user_same_email
+        ]


### PR DESCRIPTION
## Change description

* Rename `get_admin_users_queryset_by_email` to `deprecated_get_admin_users_queryset_by_email`. The change was lost by mistake in the last [PR](https://github.com/appsembler/tahoe-sites/pull/48)

* New APIs
```python
def get_organization_user_by_username_or_email(username_or_email, organization, fail_if_inactive=False):
def deprecated_is_existing_email_but_not_linked_yet(email):
```

## Type of change
- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

https://github.com/appsembler/tahoe-sites/pull/48

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
