### PR TITLE
More APIs to de-fork edx-organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- Note: Update the `Unreleased link` after adding a new release -->
 
-## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v0.1.6...HEAD)
+## [Unreleased](https://github.com/appsembler/tahoe-sites/compare/v1.3.0...HEAD)
+
+## [1.3.0](https://github.com/appsembler/tahoe-sites/compare/v1.2.0...v1.3.0) - 2022-08-11
+ - Add new API get_tahoe_sites_auth_backends
+ - Add new API get_organizations_from_uuids
+ - Add new API get_sites_from_organizations
+
+## [1.2.0](https://github.com/appsembler/tahoe-sites/compare/v1.0.0...v1.2.0) - 2022-08-02
+ - Use a versioned api path for organizations view sets
+
+## [1.0.0](https://github.com/appsembler/tahoe-sites/compare/v0.1.6...v1.0.0) - 2022-07-28
+ - Add tahoe_sites organizations viewset for Dashboard
+ - Make the package compatible with edx plugins structure
+ - Fix PyPi publish
 
 ## [0.1.6](https://github.com/appsembler/tahoe-sites/compare/v0.1.5...v0.1.6) - 2022-03-24
  - Add more APIs to support edx-platform smoothly

--- a/tahoe_sites/__init__.py
+++ b/tahoe_sites/__init__.py
@@ -1,5 +1,5 @@
 """
 tahoe-sites app initialization module
 """
-__version__ = '1.2.0'  # pragma: no cover
+__version__ = '1.3.0'  # pragma: no cover
 default_app_config = 'tahoe_sites.apps.TahoeSitesConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
## Change description

More APIs to de-fork `edx-organizations`

* Add new API `get_tahoe_sites_auth_backends`
* Add new API `get_organizations_from_uuids`
* Add new API `get_sites_from_organizations`

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

Related to: https://appsembler.atlassian.net/browse/RED-3274

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [x] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
